### PR TITLE
Fixed Mongo Connections Closed Before All Operation's Threads Finished

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ target/
 *.log
 .~lock*
 .git*
+
+.classpath
+.settings/*
+.project
+launch.json

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>3.11.2</version>
+            <version>3.12.10</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/de/idealo/mongodb/perf/Main.java
+++ b/src/main/java/de/idealo/mongodb/perf/Main.java
@@ -274,16 +274,15 @@ public class Main {
 
         int run=0;
         CountDownLatch runModeLatch = new CountDownLatch(modes.size());
-        CountDownLatch endAllOperationsLatch     = new CountDownLatch(modes.size());
+
         final ExecutorService executor = Executors.newFixedThreadPool(modes.size());
         try {
             for(int threadCount : threadCounts) {
                 if(run >= modes.size()){
                     run = 0;
                     LOG.info("All run modes are running with their specified number of threads. Waiting on finishing of each run mode before continuing...");
-                    endAllOperationsLatch.await();
+                    runModeLatch.await();
                     runModeLatch = new CountDownLatch(modes.size());
-                    endAllOperationsLatch    = new CountDownLatch(modes.size());
                 }
 
                 final String mode = modes.get(run);
@@ -318,12 +317,12 @@ public class Main {
                     operation = insertOperation;
                 }
 
-                OperationExecutor operationExecutor = new OperationExecutor(threadCount, operationsCount, maxDurationInSeconds, operation, runModeLatch, endAllOperationsLatch);
+                OperationExecutor operationExecutor = new OperationExecutor(threadCount, operationsCount, maxDurationInSeconds, operation, runModeLatch);
                 executor.execute(operationExecutor);
                 run++;
             }
 
-            endAllOperationsLatch.await();
+            runModeLatch.await();
 
         } catch (Exception e) {
             LOG.error("Error while waiting on thread.", e);

--- a/src/main/java/de/idealo/mongodb/perf/Main.java
+++ b/src/main/java/de/idealo/mongodb/perf/Main.java
@@ -274,16 +274,16 @@ public class Main {
 
         int run=0;
         CountDownLatch runModeLatch = new CountDownLatch(modes.size());
-        CountDownLatch endLatch     = new CountDownLatch(modes.size());
+        CountDownLatch endAllOperationsLatch     = new CountDownLatch(modes.size());
         final ExecutorService executor = Executors.newFixedThreadPool(modes.size());
         try {
             for(int threadCount : threadCounts) {
                 if(run >= modes.size()){
                     run = 0;
                     LOG.info("All run modes are running with their specified number of threads. Waiting on finishing of each run mode before continuing...");
-                    endLatch.await();
+                    endAllOperationsLatch.await();
                     runModeLatch = new CountDownLatch(modes.size());
-                    endLatch    = new CountDownLatch(modes.size());
+                    endAllOperationsLatch    = new CountDownLatch(modes.size());
                 }
 
                 final String mode = modes.get(run);
@@ -318,12 +318,12 @@ public class Main {
                     operation = insertOperation;
                 }
 
-                OperationExecutor operationExecutor = new OperationExecutor(threadCount, operationsCount, maxDurationInSeconds, operation, runModeLatch, endLatch);
+                OperationExecutor operationExecutor = new OperationExecutor(threadCount, operationsCount, maxDurationInSeconds, operation, runModeLatch, endAllOperationsLatch);
                 executor.execute(operationExecutor);
                 run++;
             }
 
-            endLatch.await();
+            endAllOperationsLatch.await();
 
         } catch (Exception e) {
             LOG.error("Error while waiting on thread.", e);

--- a/src/main/java/de/idealo/mongodb/perf/Main.java
+++ b/src/main/java/de/idealo/mongodb/perf/Main.java
@@ -276,11 +276,14 @@ public class Main {
         CountDownLatch runModeLatch = new CountDownLatch(modes.size());
 
         final ExecutorService executor = Executors.newFixedThreadPool(modes.size());
+
+        LOG.info("OPERATION SETUP: Total modes {}", modes.size());
+
         try {
             for(int threadCount : threadCounts) {
                 if(run >= modes.size()){
                     run = 0;
-                    LOG.info("All run modes are running with their specified number of threads. Waiting on finishing of each run mode before continuing...");
+                    LOG.info("OPERATION SETUP: All run modes are running with their specified number of threads. Waiting on finishing of each run mode before continuing...");
                     runModeLatch.await();
                     runModeLatch = new CountDownLatch(modes.size());
                 }
@@ -288,6 +291,7 @@ public class Main {
                 final String mode = modes.get(run);
                 final long operationsCount = operationsCounts.size()>run?operationsCounts.get(run):operationsCounts.get(0);
                 IOperation operation = null;
+                LOG.info("OPERATION SETUP: Adding run mode {}", mode);
                 if (mode.equals(OperationModes.UPDATE_ONE.name())) {
                     operation = new UpdateOperation(mongoDbAccessor, database, collection, IOperation.ID);
                 } else if (mode.equals(OperationModes.UPDATE_MANY.name())) {
@@ -307,9 +311,9 @@ public class Main {
                 } else {
                     InsertOperation insertOperation = new InsertOperation(mongoDbAccessor, database, collection, IOperation.ID);
                     if (dropDb) {
-                        LOG.info("drop database '{}'", database);
+                        LOG.info("OPERATION SETUP: drop database '{}'", database);
                         mongoDbAccessor.getMongoDatabase(database).drop();
-                        LOG.info("database '{}' dropped", database);
+                        LOG.info("OPERATION SETUP: database '{}' dropped", database);
                     }
                     if(randomFieldLength > 0){
                         insertOperation.setRandomFieldLength(randomFieldLength);
@@ -325,7 +329,8 @@ public class Main {
             runModeLatch.await();
 
         } catch (Exception e) {
-            LOG.error("Error while waiting on thread.", e);
+            LOG.error("OPERATION SETUP: Error while waiting on thread... exiting now.", e);
+            System.exit(-1);
         }finally {
             executor.shutdown();
             mongoDbAccessor.closeConnections();

--- a/src/main/java/de/idealo/mongodb/perf/Main.java
+++ b/src/main/java/de/idealo/mongodb/perf/Main.java
@@ -274,14 +274,16 @@ public class Main {
 
         int run=0;
         CountDownLatch runModeLatch = new CountDownLatch(modes.size());
+        CountDownLatch endLatch     = new CountDownLatch(modes.size());
         final ExecutorService executor = Executors.newFixedThreadPool(modes.size());
         try {
             for(int threadCount : threadCounts) {
                 if(run >= modes.size()){
                     run = 0;
                     LOG.info("All run modes are running with their specified number of threads. Waiting on finishing of each run mode before continuing...");
-                    runModeLatch.await();
+                    endLatch.await();
                     runModeLatch = new CountDownLatch(modes.size());
+                    endLatch    = new CountDownLatch(modes.size());
                 }
 
                 final String mode = modes.get(run);
@@ -316,12 +318,12 @@ public class Main {
                     operation = insertOperation;
                 }
 
-                OperationExecutor operationExecutor = new OperationExecutor(threadCount, operationsCount, maxDurationInSeconds, operation, runModeLatch);
+                OperationExecutor operationExecutor = new OperationExecutor(threadCount, operationsCount, maxDurationInSeconds, operation, runModeLatch, endLatch);
                 executor.execute(operationExecutor);
                 run++;
             }
 
-            runModeLatch.await();
+            endLatch.await();
 
         } catch (Exception e) {
             LOG.error("Error while waiting on thread.", e);

--- a/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
+++ b/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
@@ -50,8 +50,7 @@ public class MongoDbAccessor {
         return mongo.getDatabase(dbName);
     }
 
-
-    private void init() {
+    public void init() {
         LOG.info(">>> init {}", serverAddress);
         try {
             MongoClientOptions options = MongoClientOptions.builder().

--- a/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
+++ b/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
@@ -47,6 +47,10 @@ public class MongoDbAccessor {
     }
 
     public MongoDatabase getMongoDatabase(String dbName) {
+
+        if (mongo == null)
+            init();
+
         return mongo.getDatabase(dbName);
     }
 

--- a/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
+++ b/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
@@ -56,6 +56,8 @@ public class MongoDbAccessor {
         try {
             MongoClientOptions options = MongoClientOptions.builder().
                     connectTimeout(1000*2).//fail fast, so we know this node is unavailable
+                    maxConnectionIdleTime(1000 * 60).
+                    maxConnectionLifeTime(1000 * 60).
                     socketTimeout(socketTimeOut==-1?1000*10:socketTimeOut).//default 10 seconds
                     readPreference(ReadPreference.secondaryPreferred()).
                     connectionsPerHost(5000).

--- a/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
+++ b/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
@@ -61,7 +61,7 @@ public class MongoDbAccessor {
                     connectTimeout(1000 * 10). // fail fast, so we know this node is unavailable
                     // maxConnectionIdleTime(1000 * 60).
                     // maxConnectionLifeTime(1000 * 60).
-                    socketTimeout(socketTimeOut == -1 ? 1000 * 120 : socketTimeOut). //default 120 seconds
+                    // socketTimeout(socketTimeOut == -1 ? 1000 * 120 : socketTimeOut). // use default (no timeout)
                     readPreference(ReadPreference.secondaryPreferred()).
                     connectionsPerHost(5000).
                     threadsAllowedToBlockForConnectionMultiplier(10).

--- a/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
+++ b/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
@@ -58,10 +58,10 @@ public class MongoDbAccessor {
         LOG.info(">>> init {}", serverAddress);
         try {
             MongoClientOptions options = MongoClientOptions.builder().
-                    connectTimeout(1000*2).//fail fast, so we know this node is unavailable
+                    connectTimeout(1000 * 10). // fail fast, so we know this node is unavailable
                     // maxConnectionIdleTime(1000 * 60).
                     // maxConnectionLifeTime(1000 * 60).
-                    socketTimeout(socketTimeOut==-1?1000*10:socketTimeOut).//default 10 seconds
+                    socketTimeout(socketTimeOut == -1 ? 1000 * 120 : socketTimeOut). //default 120 seconds
                     readPreference(ReadPreference.secondaryPreferred()).
                     connectionsPerHost(5000).
                     threadsAllowedToBlockForConnectionMultiplier(10).

--- a/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
+++ b/src/main/java/de/idealo/mongodb/perf/MongoDbAccessor.java
@@ -55,8 +55,8 @@ public class MongoDbAccessor {
         try {
             MongoClientOptions options = MongoClientOptions.builder().
                     connectTimeout(1000*2).//fail fast, so we know this node is unavailable
-                    maxConnectionIdleTime(1000 * 60).
-                    maxConnectionLifeTime(1000 * 60).
+                    // maxConnectionIdleTime(1000 * 60).
+                    // maxConnectionLifeTime(1000 * 60).
                     socketTimeout(socketTimeOut==-1?1000*10:socketTimeOut).//default 10 seconds
                     readPreference(ReadPreference.secondaryPreferred()).
                     connectionsPerHost(5000).

--- a/src/main/java/de/idealo/mongodb/perf/operations/AbstractOperation.java
+++ b/src/main/java/de/idealo/mongodb/perf/operations/AbstractOperation.java
@@ -73,9 +73,13 @@ public abstract class AbstractOperation implements IOperation{
         try {
             final long lAffectedDocs = executeQuery(threadId, threadRunCount, globalRunCount, selectorId, randomId);
             affectedDocs.addAndGet(lAffectedDocs);
-        } catch (Exception e) {
-            LOG.error("error while executing query on field '{}' with value '{}'", queriedField, selectorId, e);
+        } 
+        catch (IllegalStateException ee) {
+            mongoDbAccessor.init();
         }
+        catch (Exception e) {
+            LOG.error("error while executing query on field '{}' with value '{}'", queriedField, selectorId, e);
+        } 
     }
 
     @Override

--- a/src/main/java/de/idealo/mongodb/perf/operations/AbstractOperation.java
+++ b/src/main/java/de/idealo/mongodb/perf/operations/AbstractOperation.java
@@ -75,6 +75,7 @@ public abstract class AbstractOperation implements IOperation{
             affectedDocs.addAndGet(lAffectedDocs);
         } 
         catch (IllegalStateException ee) {
+            LOG.error("mongoDbAccessor in illegal state... attempting to reconnect", ee);
             mongoDbAccessor.init();
         }
         catch (Exception e) {

--- a/src/main/java/de/idealo/mongodb/perf/operations/AbstractOperation.java
+++ b/src/main/java/de/idealo/mongodb/perf/operations/AbstractOperation.java
@@ -76,6 +76,7 @@ public abstract class AbstractOperation implements IOperation{
         } 
         catch (IllegalStateException ee) {
             LOG.error("mongoDbAccessor in illegal state... attempting to reconnect", ee);
+            mongoDbAccessor.closeConnections();
             mongoDbAccessor.init();
         }
         catch (Exception e) {


### PR DESCRIPTION
This change is to fix error below that appears caused by mongo connections being closed before all operation's threads had been stopped.

A new latch has been added that will signal to all threads when it is safe to close the mongo db connections.

Fix might be considered a bit lazy - there are probably better ways to do this with the existing latches.

```
2021-09-29 17:04:17,668 [pool-7-thread-49] ERROR d.i.m.perf.operations.IOperation - error while executing query on field 'threadRunCount' with value '552'
java.lang.IllegalStateException: The pool is closed
	at com.mongodb.internal.connection.ConcurrentPool.get(ConcurrentPool.java:137)
	at com.mongodb.internal.connection.DefaultConnectionPool.getPooledConnection(DefaultConnectionPool.java:271)
	at com.mongodb.internal.connection.DefaultConnectionPool.get(DefaultConnectionPool.java:112)
	at com.mongodb.internal.connection.DefaultConnectionPool.get(DefaultConnectionPool.java:101)
	at com.mongodb.internal.connection.DefaultServer.getConnection(DefaultServer.java:92)
	at com.mongodb.binding.ClusterBinding$ClusterBindingConnectionSource.getConnection(ClusterBinding.java:126)
	at com.mongodb.operation.FindOperation$1.call(FindOperation.java:728)
	at com.mongodb.operation.FindOperation$1.call(FindOperation.java:725)
	at com.mongodb.operation.OperationHelper.withReadConnectionSource(OperationHelper.java:463)
	at com.mongodb.operation.FindOperation.execute(FindOperation.java:725)
	at com.mongodb.operation.FindOperation.execute(FindOperation.java:89)
	at com.mongodb.client.internal.MongoClientDelegate$DelegateOperationExecutor.execute(MongoClientDelegate.java:189)
	at com.mongodb.client.internal.MongoIterableImpl.execute(MongoIterableImpl.java:143)
	at com.mongodb.client.internal.MongoIterableImpl.iterator(MongoIterableImpl.java:92)
	at de.idealo.mongodb.perf.operations.IterateOperation.executeQuery(IterateOperation.java:21)
	at de.idealo.mongodb.perf.operations.AbstractOperation.operation(AbstractOperation.java:74)
	at de.idealo.mongodb.perf.OperationExecutor.doOperation(OperationExecutor.java:91)
	at de.idealo.mongodb.perf.OperationExecutor.lambda$executeThreads$0(OperationExecutor.java:134)
	at de.idealo.mongodb.perf.OperationExecutor$$Lambda$49/0x00000000380064f0.run(Unknown Source)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:836)
```